### PR TITLE
feat: added a check that redis can write keys

### DIFF
--- a/cmd/consume/consume.go
+++ b/cmd/consume/consume.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/henrywhitaker3/go-template/internal/app"
 	"github.com/henrywhitaker3/go-template/internal/metrics"
+	"github.com/henrywhitaker3/go-template/internal/probes"
 	"github.com/henrywhitaker3/go-template/internal/queue"
 	"github.com/spf13/cobra"
 )
@@ -28,7 +29,7 @@ func New(app *app.App) *cobra.Command {
 			go func() {
 				<-cmd.Context().Done()
 				ctx := context.Background()
-				app.Probes.Unready()
+				probes.Unready()
 
 				app.Metrics.Stop(ctx)
 				app.Probes.Stop(ctx)
@@ -36,8 +37,8 @@ func New(app *app.App) *cobra.Command {
 
 			go app.Metrics.Start(cmd.Context())
 
-			app.Probes.Ready()
-			app.Probes.Healthy()
+			probes.Ready()
+			probes.Healthy()
 
 			consumer.RegisterMetrics(app.Metrics.Registry)
 

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/henrywhitaker3/go-template/internal/app"
 	"github.com/henrywhitaker3/go-template/internal/metrics"
+	"github.com/henrywhitaker3/go-template/internal/probes"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +21,7 @@ func New(app *app.App) *cobra.Command {
 			go func() {
 				<-cmd.Context().Done()
 				ctx := context.Background()
-				app.Probes.Unready()
+				probes.Unready()
 
 				app.Metrics.Stop(ctx)
 				app.Probes.Stop(ctx)
@@ -32,8 +33,8 @@ func New(app *app.App) *cobra.Command {
 
 			app.Runner.Run()
 
-			app.Probes.Ready()
-			app.Probes.Healthy()
+			probes.Ready()
+			probes.Healthy()
 
 			return app.Http.Start(cmd.Context())
 		},

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -57,7 +57,7 @@ type App struct {
 }
 
 func New(ctx context.Context, conf *config.Config) (*App, error) {
-	redis, err := redis.New(conf)
+	redis, err := redis.New(ctx, conf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/probes/probes.go
+++ b/internal/probes/probes.go
@@ -11,6 +11,14 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+var (
+	server    Probes
+	Healthy   = server.Healthy
+	Unhealthy = server.Unhealthy
+	Ready     = server.Ready
+	Unready   = server.Unready
+)
+
 type Probes struct {
 	mu *sync.RWMutex
 
@@ -21,6 +29,9 @@ type Probes struct {
 	healthy bool
 }
 
+// Creates a new probes server and assignes the default `server` var
+// to it. This way other packages can change the health status without being passed
+// a probes server
 func New(port int) *Probes {
 	p := &Probes{
 		port: port,
@@ -35,6 +46,7 @@ func New(port int) *Probes {
 	e.GET("/healthz", p.healthyHandler())
 
 	p.e = e
+	server = *p
 
 	return p
 }

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,10 +1,14 @@
 package redis
 
 import (
+	"context"
 	"errors"
 	"strings"
+	"time"
 
 	"github.com/henrywhitaker3/go-template/internal/config"
+	"github.com/henrywhitaker3/go-template/internal/logger"
+	"github.com/henrywhitaker3/go-template/internal/probes"
 	"github.com/redis/rueidis"
 	"github.com/redis/rueidis/rueidisotel"
 )
@@ -13,7 +17,7 @@ var (
 	ErrLocked = errors.New("key already locked")
 )
 
-func New(conf *config.Config) (rueidis.Client, error) {
+func New(ctx context.Context, conf *config.Config) (rueidis.Client, error) {
 	opts := rueidis.ClientOption{
 		InitAddress:   []string{conf.Redis.Addr},
 		Password:      conf.Redis.Password,
@@ -23,12 +27,37 @@ func New(conf *config.Config) (rueidis.Client, error) {
 	var client rueidis.Client
 	var err error
 	if conf.Telemetry.Tracing.Enabled {
-		client, err = rueidisotel.NewClient(opts, rueidisotel.WithDBStatement(func(cmdTokens []string) string {
-			return strings.Join(cmdTokens, " ")
-		}))
+		client, err = rueidisotel.NewClient(
+			opts,
+			rueidisotel.WithDBStatement(func(cmdTokens []string) string {
+				return strings.Join(cmdTokens, " ")
+			}),
+		)
 	} else {
 		client, err = rueidis.NewClient(opts)
 	}
 
+	go checkCanWrite(ctx, client)
+
 	return client, err
+}
+
+// Does a write to redis every second to check we can write, if it can't it marks the
+// the app as unhealthy
+func checkCanWrite(ctx context.Context, client rueidis.Client) {
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-tick.C:
+			cmd := client.B().Set().Key("redis:can-write").Value("true").Build()
+			if res := client.Do(ctx, cmd); res.Error() != nil {
+				logger.Logger(ctx).Errorw("could not write to redis", "error", res.Error())
+				probes.Unhealthy()
+			}
+		}
+	}
 }


### PR DESCRIPTION
When dragonfly changes master, persistent connections can leave you still connected to the read-only replica